### PR TITLE
Fix restart command after custom env changes

### DIFF
--- a/recipes/restart_command.rb
+++ b/recipes/restart_command.rb
@@ -6,7 +6,7 @@ node[:deploy].each do |application, deploy|
 
   execute "restart Rails app #{application} for custom env" do
     cwd deploy[:current_path]
-    command node[:opsworks][:rails_stack][:restart_command]
+    command deploy[:restart_command]
 
     action :nothing
   end


### PR DESCRIPTION
we can't use opsworks key in stack setting json because aws now removes that key before using those settings